### PR TITLE
fix: always show `≈` for usd value

### DIFF
--- a/packages/site/src/pages/Overview/CustomLabel.js
+++ b/packages/site/src/pages/Overview/CustomLabel.js
@@ -171,7 +171,7 @@ const Label = ({ data, icon, status, clickEvent }) => {
         {!!fiatValue && (
           <ValueWrapper disabled={disabled}>
             <TextFiatValue>
-              ${Math.round(fiatValue).toLocaleString()}
+              ≈ ${Math.round(fiatValue).toLocaleString()}
             </TextFiatValue>
           </ValueWrapper>
         )}
@@ -214,7 +214,7 @@ const Label = ({ data, icon, status, clickEvent }) => {
             {!!item.fiatValue && (
               <ValueWrapper disabled={disabled}>
                 <TextFiatValue>
-                  ${Math.round(item.fiatValue).toLocaleString()}
+                  ≈ ${Math.round(item.fiatValue).toLocaleString()}
                 </TextFiatValue>
               </ValueWrapper>
             )}

--- a/packages/site/src/pages/Overview/Summary.js
+++ b/packages/site/src/pages/Overview/Summary.js
@@ -45,6 +45,7 @@ import { breakpoint, smcss } from "../../styles/responsive";
 import { useIsKusamaChain } from "../../utils/hooks/chain";
 import { extractTime } from "@polkadot/util";
 import { parseEstimateTime } from "../../utils/parseEstimateTime";
+import BigNumber from "bignumber.js";
 
 const Wrapper = styled(Card)`
   margin-bottom: 24px;
@@ -136,8 +137,10 @@ const Summary = () => {
   const precision = getPrecision(symbol);
 
   const symbolPrice = overview?.latestSymbolPrice ?? 0;
-  const toBeAwarded = overview?.toBeAwarded?.total ?? 0;
-  const toBeAwardedValue = toPrecision(toBeAwarded, precision);
+  const toBeAwarded = BigNumber(overview?.toBeAwarded?.total ?? 0).toNumber();
+  const toBeAwardedValue = BigNumber(
+    toPrecision(toBeAwarded, precision)
+  ).toNumber();
 
   return (
     <Wrapper>
@@ -153,7 +156,8 @@ const Summary = () => {
               <TextAccessoryBold>{symbol}</TextAccessoryBold>
             </ValueWrapper>
             <ValueInfo>
-              ${abbreviateBigNumber(treasury.free * symbolPrice)}
+              {!!treasury.free && "≈ "}$
+              {abbreviateBigNumber(treasury.free * symbolPrice)}
             </ValueInfo>
           </div>
         </ItemWrapper>
@@ -170,7 +174,8 @@ const Summary = () => {
               <TextAccessoryBold>{symbol}</TextAccessoryBold>
             </ValueWrapper>
             <ValueInfo>
-              ${abbreviateBigNumber(toBeAwardedValue * symbolPrice)}
+              {!!toBeAwardedValue && "≈ "}$
+              {abbreviateBigNumber(toBeAwardedValue * symbolPrice)}
             </ValueInfo>
           </div>
         </ItemWrapper>


### PR DESCRIPTION
<img width="584" alt="image" src="https://user-images.githubusercontent.com/19513289/218976497-b4481f67-cf3a-47d6-ad8c-5939794d99e7.png">
<img width="881" alt="image" src="https://user-images.githubusercontent.com/19513289/218976546-4fa70a53-a370-4744-8012-781b804d18ca.png">
